### PR TITLE
Optional support of comments and some other stuff

### DIFF
--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -20,9 +20,9 @@ public:
 	//! Constructor
 	/*! \param stream Output stream.
 		\param allocator User supplied allocator. If it is null, it will create a private one.
-		\param levelDepth Initial capacity of 
+		\param levelDepth Initial capacity of
 	*/
-	PrettyWriter(Stream& stream, Allocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) : 
+	PrettyWriter(Stream& stream, Allocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) :
 		Base(stream, allocator, levelDepth), indentChar_(' '), indentCharCount_(4) {}
 
 	//! Set custom indentation.
@@ -138,7 +138,7 @@ protected:
 				RAPIDJSON_ASSERT(type == kStringType);  // if it's in object, then even number should be a name
 			level->valueCount++;
 		}
-		else
+		else if ((this->flags_ & kSerializeAnyValueFlag) == 0)
 			RAPIDJSON_ASSERT(type == kObjectType || type == kArrayType);
 	}
 

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -171,7 +171,7 @@ inline const char *SkipWhitespace_SIMD(const char* p) {
 
 #ifdef RAPIDJSON_SIMD
 //! Template function specialization for InsituStringStream
-template<> inline void SkipWhitespace(InsituStringStream& stream) { 
+template<> inline void SkipWhitespace(InsituStringStream& stream) {
 	stream.src_ = const_cast<char*>(SkipWhitespace_SIMD(stream.src_));
 }
 
@@ -185,17 +185,17 @@ template<> inline void SkipWhitespace(StringStream& stream) {
 // GenericReader
 
 //! SAX-style JSON parser. Use Reader for UTF8 encoding and default allocator.
-/*! GenericReader parses JSON text from a stream, and send events synchronously to an 
+/*! GenericReader parses JSON text from a stream, and send events synchronously to an
     object implementing Handler concept.
 
-    It needs to allocate a stack for storing a single decoded string during 
+    It needs to allocate a stack for storing a single decoded string during
     non-destructive parsing.
 
-    For in-situ parsing, the decoded string is directly written to the source 
+    For in-situ parsing, the decoded string is directly written to the source
     text string, no temporary buffer is required.
 
     A GenericReader object can be reused for parsing multiple JSON text.
-    
+
     \tparam Encoding Encoding of both the stream and the parse output.
     \tparam Allocator Allocator type for stack.
 */
@@ -211,7 +211,7 @@ public:
 	GenericReader(Allocator* allocator = 0, size_t stackCapacity = kDefaultStackCapacity) : stack_(allocator, stackCapacity), parseError_(0), errorOffset_(0) {}
 
 	//! Parse JSON text.
-	/*! \tparam parseFlags Combination of ParseFlag. 
+	/*! \tparam parseFlags Combination of ParseFlag.
 		 \tparam Stream Type of input stream.
 		 \tparam Handler Type of handler which must implement Handler concept.
 		 \param stream Input stream to be parsed.
@@ -243,11 +243,14 @@ public:
 			switch (stream.Peek()) {
 				case '{': ParseObject<parseFlags>(stream, handler); break;
 				case '[': ParseArray<parseFlags>(stream, handler); break;
-				default: RAPIDJSON_PARSE_ERROR("Expect either an object or array at root", stream.Tell());
+				default: {
+					stream.Take();
+					RAPIDJSON_PARSE_ERROR("Expect either an object or array at root", stream.Tell());
+				}
 			}
 			SkipWhitespace(stream);
 
-			if ((parseFlags & kParseStreamFlag) == 0 && stream.Peek() != '\0')
+			if ((parseFlags & kParseStreamFlag) == 0 && stream.Take() != '\0')
 				RAPIDJSON_PARSE_ERROR("Nothing should follow the root object or array.", stream.Tell());
 		}
 
@@ -275,6 +278,7 @@ private:
 
 		for (SizeType memberCount = 0;;) {
 			if (stream.Peek() != '"') {
+				stream.Take();
 				RAPIDJSON_PARSE_ERROR("Name of an object member must be a string", stream.Tell());
 				break;
 			}
@@ -376,7 +380,7 @@ private:
 				codepoint -= 'A' - 10;
 			else if (c >= 'a' && c <= 'f')
 				codepoint -= 'a' - 10;
-			else 
+			else
 				RAPIDJSON_PARSE_ERROR("Incorrect hex digit after \\u escape", s.Tell() - 1);
 		}
 		stream = s; // Restore stream
@@ -388,10 +392,10 @@ private:
 	void ParseString(Stream& stream, Handler& handler) {
 #define Z16 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 		static const Ch escape[256] = {
-			Z16, Z16, 0, 0,'\"', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,'/', 
-			Z16, Z16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,'\\', 0, 0, 0, 
-			0, 0,'\b', 0, 0, 0,'\f', 0, 0, 0, 0, 0, 0, 0,'\n', 0, 
-			0, 0,'\r', 0,'\t', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+			Z16, Z16, 0, 0,'\"', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,'/',
+			Z16, Z16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,'\\', 0, 0, 0,
+			0, 0,'\b', 0, 0, 0,'\f', 0, 0, 0, 0, 0, 0, 0,'\n', 0,
+			0, 0,'\r', 0,'\t', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			Z16, Z16, Z16, Z16, Z16, Z16, Z16, Z16
 		};
 #undef Z16
@@ -440,7 +444,7 @@ private:
 					Ch buffer[4];
 					SizeType count = SizeType(Encoding::Encode(buffer, codepoint) - &buffer[0]);
 
-					if (parseFlags & kParseInsituFlag) 
+					if (parseFlags & kParseInsituFlag)
 						for (SizeType i = 0; i < count; i++)
 							s.Put(buffer[i]);
 					else {
@@ -523,6 +527,7 @@ private:
 				}
 		}
 		else {
+			stream.Take();
 			RAPIDJSON_PARSE_ERROR("Expect a value here.", stream.Tell());
 			return;
 		}
@@ -532,8 +537,8 @@ private:
 		bool useDouble = false;
 		if (try64bit) {
 			i64 = i;
-			if (minus) 
-				while (s.Peek() >= '0' && s.Peek() <= '9') {					
+			if (minus)
+				while (s.Peek() >= '0' && s.Peek() <= '9') {
 					if (i64 >= 922337203685477580uLL) // 2^63 = 9223372036854775808
 						if (i64 != 922337203685477580uLL || s.Peek() > '8') {
 							useDouble = true;
@@ -542,7 +547,7 @@ private:
 					i64 = i64 * 10 + (s.Take() - '0');
 				}
 			else
-				while (s.Peek() >= '0' && s.Peek() <= '9') {					
+				while (s.Peek() >= '0' && s.Peek() <= '9') {
 					if (i64 >= 1844674407370955161uLL) // 2^64 - 1 = 18446744073709551615
 						if (i64 != 1844674407370955161uLL || s.Peek() > '5') {
 							useDouble = true;
@@ -579,6 +584,7 @@ private:
 				--expFrac;
 			}
 			else {
+				stream.Take();
 				RAPIDJSON_PARSE_ERROR("At least one digit in fraction part", stream.Tell());
 				return;
 			}
@@ -620,6 +626,7 @@ private:
 				}
 			}
 			else {
+				stream.Take();
 				RAPIDJSON_PARSE_ERROR("At least one digit in exponent", s.Tell());
 				return;
 			}
@@ -665,7 +672,7 @@ private:
 		}
 	}
 
-	static const size_t kDefaultStackCapacity = 256;	//!< Default stack capacity in bytes for storing a single decoded string. 
+	static const size_t kDefaultStackCapacity = 256;	//!< Default stack capacity in bytes for storing a single decoded string.
 	internal::Stack<Allocator> stack_;	//!< A stack for storing decoded string temporarily during non-destructive parsing.
 	jmp_buf jmpbuf_;					//!< setjmp buffer for fast exit from nested parsing function calls.
 	const char* parseError_;

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -272,13 +272,21 @@ private:
 			while (stream.Peek() == '/') {
 				stream.Take();
 
-				if (stream.Take() != '*') {
-					RAPIDJSON_PARSE_ERROR("Comments must start with /*", stream.Tell());
-					break;
-				}
+				if (stream.Peek() == '*') {
+					stream.Take();
 
-				while (stream.Take() != '*' || stream.Take() != '/') {
-					// Do nothing because of that awful logical expression with side effects.
+					while (stream.Take() != '*' || stream.Take() != '/') {
+						// Do nothing because of that awful logical expression with side effects.
+					}
+				} else if (stream.Peek() == '/') {
+					stream.Take();
+
+					while (stream.Take() != '\n') {
+						// Empty.
+					}
+				} else {
+					RAPIDJSON_PARSE_ERROR("Comments must start with /* or //", stream.Tell());
+					break;
 				}
 
 				SkipWhitespace(stream);

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -517,7 +517,15 @@ TEST(Reader, Parse_Error) {
 #endif // RAPIDJSON_USE_EXCEPTION
 
 TEST(Reader, Comments) {
-	const char* json = "/* Here is a comment. */ {/*And here's another one.*/\"hello\" : \"world\", \"t\" : /* And one more to be sure*/true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }/*The last one to be super-sure*/";
+	const char* json =
+	"// Here is a one-line comment.\n"
+	"{// And here's another one\n"
+	"	/*And here's an in-line one.*/\"hello\" : \"world\","
+	"	\"t\" :/* And one with '*' symbol*/true ,"
+	"/* A multiline comment\n"
+	"   goes here*/"
+	"	\"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3]"
+	"}/*The last one to be super-sure */";
 
 	StringStream s(json);
 	ParseObjectHandler h;
@@ -526,8 +534,47 @@ TEST(Reader, Comments) {
 	EXPECT_EQ(20u, h.step_);
 }
 
-TEST(Reader, CommentsAreDisabledByDefault) {
-	const char* json = "/* Here is a comment. */ {/*And here's another one.*/\"hello\" : \"world\", \"t\" : /* And one more to be sure*/true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }/*The last one to be super-sure*/";
+TEST(Reader, InlineCommentsAreDisabledByDefault1) {
+	const char* json = "/* Inline comment. */ {\"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
+
+	StringStream s(json);
+	ParseObjectHandler h;
+	Reader reader;
+	EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
+}
+
+TEST(Reader, InlineCommentsAreDisabledByDefault2) {
+	const char* json = "{\"hello\" : \"world\", \"t\" : /* Inline comment. */ true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
+
+	StringStream s(json);
+	ParseObjectHandler h;
+	Reader reader;
+	EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
+}
+
+TEST(Reader, MultilineCommentsAreDisabledByDefault) {
+	const char* json =
+	"{\"hello\" : /* Multiline comment starts here\n"
+	" continues here\n"
+	" and ends here */\"world\", \"t\" :true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
+
+	StringStream s(json);
+	ParseObjectHandler h;
+	Reader reader;
+	EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
+}
+
+TEST(Reader, OnelineCommentsAreDisabledByDefault1) {
+	const char* json = "// One-line comment\n {\"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
+
+	StringStream s(json);
+	ParseObjectHandler h;
+	Reader reader;
+	EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
+}
+
+TEST(Reader, OnelineCommentsAreDisabledByDefault2) {
+	const char* json = "{\"hello\" : \"world\",// One-line comment\n \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
 	StringStream s(json);
 	ParseObjectHandler h;


### PR DESCRIPTION
This PR introduces:
- Writer can serialize not only JSON object and arrays, but all other types too. It's already used in the util's dynamic_t to print dynamic_t objects to std::ostream.
- Fixed offsets of some errors returned by the reader. Sometimes rapidjson points before the actual error position, and this weird behaviour caused config_t to handle these cases with kludges.
  This functionality is already used by the util from a branch.
- Optional `/* */` and `//` comments support. I'm going to use this option in config_t, because having comments in configs is a great good.
